### PR TITLE
Release 20251211 - `/project` 全部结果并排序

### DIFF
--- a/src/notify_admin/__init__.py
+++ b/src/notify_admin/__init__.py
@@ -1,4 +1,4 @@
-from fastapi import Request, APIRouter
+from fastapi import Request, APIRouter, HTTPException
 from aiohttp import ClientSession
 from loguru import logger
 
@@ -8,7 +8,12 @@ router = APIRouter()
 
 @router.post("/notify_admin")
 async def notify_admin(request: Request):
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception as e:
+        logger.error(f"notify_admin invalid json: {e}")
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
     logger.info(str(body))
 
     if not settings.notify_admin_url:

--- a/src/project/__init__.py
+++ b/src/project/__init__.py
@@ -43,8 +43,7 @@ async def query_project(type_id: str = "GameTools"):
             ],
             "download": p.download,
         }
-        for p in project_cache[0]
-        if p.type_id == type_id
+        for p in sorted(project_cache[0], key=lambda p: p.type_id != type_id)
     ]
 
     return {"ec": 200, "data": data}


### PR DESCRIPTION
## Summary by Sourcery

在管理员通知端点中处理无效的 JSON 负载，并调整项目查询结果的排序以优先显示特定的 `type_id`。

Bug Fixes:
- 当 `/notify_admin` 端点接收到无效的 JSON 请求体时，返回 400 错误。

Enhancements:
- 从 `/project` 查询中返回所有缓存的项目，并通过排序使具有请求 `type_id` 的条目优先显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle invalid JSON payloads in the admin notification endpoint and adjust project query results ordering to prioritize a specific type_id.

Bug Fixes:
- Return a 400 error when the /notify_admin endpoint receives an invalid JSON body.

Enhancements:
- Return all cached projects from the /project query while sorting them to show entries with the requested type_id first.

</details>